### PR TITLE
submitTrade fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ let Cryptopia = function () {
         },
         submitTrade: async function (params, callback) {
             params = params || {};
-            if (!params.Market || !params.TradePairId) {
+            if (!params.Market && !params.TradePairId) {
                 return callback(new Error("You must supply a valid Market, e.g. 'BTC/USDT' OR you must supply a valid Trade Pair ID, e.g. '100'!"));
             } else if (params.TradePairId && typeof params.TradePairId !== 'number') {
                 return callback(new Error("You must supply a valid Trade Pair ID, e.g. '100'!"));


### PR DESCRIPTION
submitTrade function should be working if either Market or TradePairID is passed in params.
However "if (!params.Market || !params.TradePairId) --> False if only one of them is passed.
Should be changed to if (!params.Market && !params.TradePairId)
The example also raises error due to this.