### PR TITLE
Remove unnecessary param checks for tradeHistory 

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,9 +112,7 @@ let Cryptopia = () => {
             return privateRequest(reqOpts);
         },
         getTradeHistory: async (params = {}) => {
-            if (!params.Market && !params.TradePairId) {
-                return Promise.reject("getTradeHistory(), You must supply a valid Market, e.g. 'BTC/USDT' OR you must supply a valid Trade Pair ID, e.g. '100'!");
-            } else if (params.TradePairId && typeof params.TradePairId !== 'number') {
+            if (params.TradePairId && typeof params.TradePairId !== 'number') {
                 return Promise.reject("getTradeHistory(), You must supply a valid Trade Pair ID, e.g. '100'!");
             } else if (params.Market && typeof params.Market !== 'string') {
                 return Promise.reject("getTradeHistory(), You must supply a valid Market, e.g. 'DOT/BTC'!");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptopia-api",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Asynchronous Node.js Module for accessing both Public and Private Cryptopia APIs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently for `getTradeHistory`, the `Market` and `TradePairId` params are required.

These are no longer required, so i've removed the conditional that would cause a rejection if not provided. 😄 🎉

Also bumped the version for easier merging. 👍 